### PR TITLE
separating accessibilityUnit from accessibilityMinutes and accessibilityHours

### DIFF
--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -20,6 +20,8 @@ const UIView = {
   accessibilityRole: true,
   accessibilityState: true,
   accessibilityUnit: true,
+  accessibilityHours: true,
+  accessibilityMinutes: true,
   accessibilityValue: true,
   accessibilityHint: true,
   accessibilityLanguage: true,

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -38,6 +38,8 @@ const View: React.AbstractComponent<
       accessibilityRole,
       accessibilityState,
       accessibilityUnit,
+      accessibilityHours,
+      accessibilityMinutes,
       accessibilityValue,
       'aria-busy': ariaBusy,
       'aria-checked': ariaChecked,

--- a/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/Libraries/Components/View/ViewAccessibility.d.ts
@@ -47,6 +47,8 @@ export interface AccessibilityProps
    */
   accessibilityState?: AccessibilityState | undefined;
   accessibilityUnit?: AccessibilityUnit | undefined;
+  accessibilityHours?: number | undefined;
+  accessibilityMinutes?: number | undefined;
 
   /**
    * alias for accessibilityState

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -503,6 +503,8 @@ export type ViewProps = $ReadOnly<{|
    */
   accessibilityState?: ?AccessibilityState,
   accessibilityUnit?: ?Stringish,
+  accessibilityHours?: ?number,
+  accessibilityMinutes?: ?number,
   accessibilityValue?: ?AccessibilityValue,
 
   /**

--- a/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -177,6 +177,8 @@ const validAttributesForNonEventProps = {
   accessibilityCollectionItem: true,
   accessibilityState: true,
   accessibilityUnit: true,
+  accessibilityHours: true,
+  accessibilityMinutes: true,
   accessibilityActions: true,
   accessibilityValue: true,
   importantForAccessibility: true,

--- a/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -190,6 +190,8 @@ const validAttributesForNonEventProps = {
   accessibilityRole: true,
   accessibilityState: true,
   accessibilityUnit: false,
+  accessibilityHours: false,
+  accessibilityMinutes: false,
   nativeID: true,
   pointerEvents: true,
   removeClippedSubviews: true,

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -225,6 +225,8 @@ const Text: React.AbstractComponent<
       {...restProps}
       accessibilityState={_accessibilityState}
       accessibilityUnit={props.accessibilityUnit}
+      accessibilityHours={props.accessibilityHours}
+      accessibilityMinutes={props.accessibilityMinutes}
       {...eventHandlersForText}
       accessibilityLabel={ariaLabel ?? accessibilityLabel}
       accessibilityRole={
@@ -245,6 +247,8 @@ const Text: React.AbstractComponent<
         {...restProps}
         {...eventHandlersForText}
         accessibilityUnit={props.accessibilityUnit}
+        accessibilityHours={props.accessibilityHours}
+        accessibilityMinutes={props.accessibilityMinutes}
         disabled={_disabled}
         selectable={_selectable}
         accessible={

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -11,7 +11,6 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.TextUtils;
 import android.util.LayoutDirection;
-import android.util.Log;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -106,6 +105,7 @@ public class TextAttributeProps {
   protected boolean mIsAccessibilityRoleSet = false;
   protected @Nullable String mAccessibilityUnit = null;
   protected boolean mIsAccessibilityLink = false;
+  protected boolean mIsAccessibilityTtsSpan = false;
 
   protected int mFontStyle = UNSET;
   protected int mFontWeight = UNSET;
@@ -612,15 +612,15 @@ public class TextAttributeProps {
       mIsAccessibilityLink = mAccessibilityRole.equals(AccessibilityRole.LINK);
       String roleClassName =
           AccessibilityRole.getValue(AccessibilityRole.fromValue(accessibilityRole));
-      mAccessibilityUnit =
-          ReactTtsSpan.SUPPORTED_UNIT_TYPES.contains(roleClassName) ? roleClassName : null;
+      mIsAccessibilityTtsSpan =
+          ReactTtsSpan.SUPPORTED_UNIT_TYPES.contains(roleClassName) && Build.VERSION.SDK_INT >= 21;
     }
   }
 
   private void setAccessibilityUnit(@Nullable String accessibilityUnit) {
-    Log.w("TESTING::TextAttributeProps", "setAccessibilityUnit");
-    Log.w("TESTING::TextAttributeProps", "accessibilityUnit: " + (accessibilityUnit));
-    // not yet implemented
+    if (accessibilityUnit != null) {
+      mAccessibilityUnit = accessibilityUnit;
+    }
   }
 
   public static int getTextBreakStrategy(@Nullable String textBreakStrategy) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.text.Layout;
 import android.text.TextUtils;
 import android.util.LayoutDirection;
+import android.util.Log;
 import android.view.Gravity;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -54,6 +55,8 @@ public class TextAttributeProps {
   public static final short TA_KEY_LAYOUT_DIRECTION = 21;
   public static final short TA_KEY_ACCESSIBILITY_ROLE = 22;
   public static final short TA_KEY_ACCESSIBILITY_UNIT = 47;
+  public static final short TA_KEY_ACCESSIBILITY_HOURS = 48;
+  public static final short TA_KEY_ACCESSIBILITY_MINUTES = 49;
 
   public static final int UNSET = -1;
 
@@ -210,6 +213,12 @@ public class TextAttributeProps {
           break;
         case TA_KEY_ACCESSIBILITY_UNIT:
           result.setAccessibilityUnit(entry.getStringValue());
+          break;
+        case TA_KEY_ACCESSIBILITY_HOURS:
+          result.setAccessibilityHours(entry.getIntValue());
+          break;
+        case TA_KEY_ACCESSIBILITY_MINUTES:
+          result.setAccessibilityMinutes(entry.getIntValue());
           break;
       }
     }
@@ -620,6 +629,18 @@ public class TextAttributeProps {
   private void setAccessibilityUnit(@Nullable String accessibilityUnit) {
     if (accessibilityUnit != null) {
       mAccessibilityUnit = accessibilityUnit;
+    }
+  }
+
+  private void setAccessibilityHours(@Nullable Integer accessibilityHours) {
+    if (accessibilityHours != null) {
+      Log.w("TESTING::TextAttributeProps", "accessibilityHours: " + (accessibilityHours));
+    }
+  }
+
+  private void setAccessibilityMinutes(@Nullable Integer accessibilityMinutes) {
+    if (accessibilityMinutes != null) {
+      Log.w("TESTING::TextAttributeProps", "accessibilityMinutes: " + (accessibilityMinutes));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -19,6 +19,7 @@ import android.text.Spanned;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.LayoutDirection;
+import android.util.Log;
 import android.util.LruCache;
 import android.view.View;
 import androidx.annotation.NonNull;
@@ -143,8 +144,12 @@ public class TextLayoutManagerMapBuffer {
         if (textAttributes.mIsAccessibilityLink) {
           ops.add(new SetSpanOperation(start, end, new ReactClickableSpan(reactTag)));
         }
-        if (textAttributes.mAccessibilityUnit != null && Build.VERSION.SDK_INT >= 21) {
+        if (textAttributes.mIsAccessibilityTtsSpan) {
+          // check that textAttributes.mAccessibilityRole == "time"
           ReactTtsSpan.Builder builder = new ReactTtsSpan.Builder(ReactTtsSpan.TYPE_TIME);
+          Log.w(
+              "TESTING::TextLayoutManagerMapBuffer",
+              "textAttributes.mAccessibilityUnit: " + (textAttributes.mAccessibilityUnit));
           builder.setIntArgument(ReactTtsSpan.ARG_HOURS, 10);
           builder.setIntArgument(ReactTtsSpan.ARG_MINUTES, 30);
           ops.add(new SetSpanOperation(start, end, builder.build()));

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -100,6 +100,10 @@ void TextAttributes::apply(TextAttributes textAttributes) {
       : accessibilityRole;
   accessibilityUnit = !textAttributes.accessibilityUnit.empty() ? textAttributes.accessibilityUnit
                                                   : accessibilityUnit;
+  accessibilityHours = !(textAttributes.accessibilityHours == 0) ? textAttributes.accessibilityHours
+                                                  : accessibilityHours;
+  accessibilityMinutes = !(textAttributes.accessibilityMinutes == 0) ? textAttributes.accessibilityMinutes
+                                                  : accessibilityMinutes;
 }
 
 #pragma mark - Operators
@@ -125,6 +129,8 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              layoutDirection,
              accessibilityRole,
              accessibilityUnit,
+             accessibilityHours,
+             accessibilityMinutes,
              textTransform) ==
       std::tie(
              rhs.foregroundColor,
@@ -146,6 +152,8 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              rhs.layoutDirection,
              rhs.accessibilityRole,
              rhs.accessibilityUnit,
+             rhs.accessibilityHours,
+             rhs.accessibilityMinutes,
              rhs.textTransform) &&
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -98,7 +98,7 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   accessibilityRole = textAttributes.accessibilityRole.has_value()
       ? textAttributes.accessibilityRole
       : accessibilityRole;
-  accessibilityUnit = !textAttributes.accessibilityUnit.has_value() ? textAttributes.accessibilityUnit
+  accessibilityUnit = !textAttributes.accessibilityUnit.empty() ? textAttributes.accessibilityUnit
                                                   : accessibilityUnit;
 }
 

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -100,9 +100,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
       : accessibilityRole;
   accessibilityUnit = !textAttributes.accessibilityUnit.empty() ? textAttributes.accessibilityUnit
                                                   : accessibilityUnit;
-  accessibilityHours = !(textAttributes.accessibilityHours == 0) ? textAttributes.accessibilityHours
+  accessibilityHours = !textAttributes.accessibilityHours.empty() ? textAttributes.accessibilityHours
                                                   : accessibilityHours;
-  accessibilityMinutes = !(textAttributes.accessibilityMinutes == 0) ? textAttributes.accessibilityMinutes
+  accessibilityMinutes = !textAttributes.accessibilityMinutes.empty() ? textAttributes.accessibilityMinutes
                                                   : accessibilityMinutes;
 }
 
@@ -222,6 +222,8 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
       debugStringConvertibleItem("layoutDirection", layoutDirection),
       debugStringConvertibleItem("accessibilityRole", accessibilityRole),
       debugStringConvertibleItem("accessibilityUnit", accessibilityUnit),
+      debugStringConvertibleItem("accessibilityHours", accessibilityHours),
+      debugStringConvertibleItem("accessibilityMinutes", accessibilityMinutes),
   };
 }
 #endif

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -79,7 +79,7 @@ class TextAttributes : public DebugStringConvertible {
   // construction.
   std::optional<LayoutDirection> layoutDirection{};
   std::optional<AccessibilityRole> accessibilityRole{};
-  AccessibilityUnit accessibilityUnit{};
+  std::string accessibilityUnit{};
 
 #pragma mark - Operations
 

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -80,8 +80,8 @@ class TextAttributes : public DebugStringConvertible {
   std::optional<LayoutDirection> layoutDirection{};
   std::optional<AccessibilityRole> accessibilityRole{};
   std::string accessibilityUnit{};
-  int accessibilityHours{};
-  int accessibilityMinutes{};
+  std::string accessibilityHours{};
+  std::string accessibilityMinutes{};
 
 #pragma mark - Operations
 

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -80,6 +80,8 @@ class TextAttributes : public DebugStringConvertible {
   std::optional<LayoutDirection> layoutDirection{};
   std::optional<AccessibilityRole> accessibilityRole{};
   std::string accessibilityUnit{};
+  int accessibilityHours{};
+  int accessibilityMinutes{};
 
 #pragma mark - Operations
 
@@ -133,7 +135,9 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.isHighlighted,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
-        textAttributes.accessibilityUnit);
+        textAttributes.accessibilityUnit,
+        textAttributes.accessibilityHours,
+        textAttributes.accessibilityMinutes);
   }
 };
 } // namespace std

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -1013,11 +1013,11 @@ inline folly::dynamic toDynamic(const TextAttributes &textAttributes) {
     _textAttributes(
         "accessibilityUnit", textAttributes.accessibilityUnit);
   }
-  if (!(textAttributes.accessibilityHours == 0)) {
+  if (!textAttributes.accessibilityHours.empty()) {
     _textAttributes(
         "accessibilityHours", textAttributes.accessibilityHours);
   }
-  if (!(textAttributes.accessibilityMinutes == 0)) {
+  if (!textAttributes.accessibilityMinutes.empty()) {
     _textAttributes(
         "accessibilityMinutes", textAttributes.accessibilityMinutes);
   }
@@ -1250,14 +1250,14 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
     builder.putString(
         TA_KEY_ACCESSIBILITY_UNIT, textAttributes.accessibilityUnit);
   }
-  if (!(textAttributes.accessibilityHours == 0)) {
+  if (!textAttributes.accessibilityHours.empty()) {
 
-    builder.putInt(
+    builder.putString(
         TA_KEY_ACCESSIBILITY_HOURS, textAttributes.accessibilityHours);
   }
-  if (!(textAttributes.accessibilityMinutes == 0)) {
+  if (!textAttributes.accessibilityMinutes.empty()) {
 
-    builder.putInt(
+    builder.putString(
         TA_KEY_ACCESSIBILITY_MINUTES, textAttributes.accessibilityMinutes);
   }
   return builder.build();

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -1013,6 +1013,14 @@ inline folly::dynamic toDynamic(const TextAttributes &textAttributes) {
     _textAttributes(
         "accessibilityUnit", textAttributes.accessibilityUnit);
   }
+  if (!(textAttributes.accessibilityHours == 0)) {
+    _textAttributes(
+        "accessibilityHours", textAttributes.accessibilityHours);
+  }
+  if (!(textAttributes.accessibilityMinutes == 0)) {
+    _textAttributes(
+        "accessibilityMinutes", textAttributes.accessibilityMinutes);
+  }
   return _textAttributes;
 }
 
@@ -1088,6 +1096,8 @@ constexpr static MapBuffer::Key TA_KEY_LAYOUT_DIRECTION = 21;
 constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_ROLE = 22;
 constexpr static MapBuffer::Key TA_KEY_LINE_BREAK_STRATEGY = 23;
 constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_UNIT = 47;
+constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_HOURS = 48;
+constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_MINUTES = 49;
 
 // constants for ParagraphAttributes serialization
 constexpr static MapBuffer::Key PA_KEY_MAX_NUMBER_OF_LINES = 0;
@@ -1239,6 +1249,16 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
 
     builder.putString(
         TA_KEY_ACCESSIBILITY_UNIT, textAttributes.accessibilityUnit);
+  }
+  if (!(textAttributes.accessibilityHours == 0)) {
+
+    builder.putInt(
+        TA_KEY_ACCESSIBILITY_HOURS, textAttributes.accessibilityHours);
+  }
+  if (!(textAttributes.accessibilityMinutes == 0)) {
+
+    builder.putInt(
+        TA_KEY_ACCESSIBILITY_MINUTES, textAttributes.accessibilityMinutes);
   }
   return builder.build();
 }

--- a/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -135,10 +135,6 @@ enum class AccessibilityRole {
   Toolbar,
 };
 
-struct AccessibilityUnit {
-  std::string hours{""};
-};
-
 enum class TextTransform {
   None,
   Uppercase,

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -298,7 +298,7 @@ void BaseTextProps::setProp(
         defaults,
         value,
         textAttributes,
-        accessibilityRole,
+        accessibilityUnit,
         "accessibilityUnit");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, opacity, "opacity");

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -183,6 +183,18 @@ static TextAttributes convertRawProp(
       "accessibilityUnit",
       sourceTextAttributes.accessibilityUnit,
       defaultTextAttributes.accessibilityUnit);
+  textAttributes.accessibilityHours = convertRawProp(
+      context,
+      rawProps,
+      "accessibilityHours",
+      sourceTextAttributes.accessibilityHours,
+      defaultTextAttributes.accessibilityHours);
+  textAttributes.accessibilityMinutes = convertRawProp(
+      context,
+      rawProps,
+      "accessibilityMinutes",
+      sourceTextAttributes.accessibilityMinutes,
+      defaultTextAttributes.accessibilityMinutes);
 
   // Color (accessed in this order by ViewProps)
   textAttributes.opacity = convertRawProp(
@@ -300,6 +312,18 @@ void BaseTextProps::setProp(
         textAttributes,
         accessibilityUnit,
         "accessibilityUnit");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults,
+        value,
+        textAttributes,
+        accessibilityHours,
+        "accessibilityHours");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults,
+        value,
+        textAttributes,
+        accessibilityMinutes,
+        "accessibilityMinutes");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, opacity, "opacity");
     REBUILD_FIELD_SWITCH_CASE(

--- a/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -45,6 +45,24 @@ AccessibilityProps::AccessibilityProps(
                     "accessibilityUnit",
                     sourceProps.accessibilityUnit,
                     {})),
+      accessibilityHours(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.accessibilityHours
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessibilityHours",
+                    sourceProps.accessibilityHours,
+                    {})),
+      accessibilityMinutes(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.accessibilityMinutes
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessibilityMinutes",
+                    sourceProps.accessibilityMinutes,
+                    {})),
       accessibilityLabel(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.accessibilityLabel
@@ -221,6 +239,8 @@ void AccessibilityProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessible, false);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityState, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityUnit, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHours, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityMinutes, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabel, std::string{""});
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabelledBy, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHint, std::string{""});

--- a/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -40,8 +40,8 @@ class AccessibilityProps {
   bool accessible{false};
   AccessibilityState accessibilityState;
   AccessibilityUnit accessibilityUnit;
-  int accessibilityHours;
-  int accessibilityMinutes;
+  AccessibilityUnit accessibilityHours;
+  AccessibilityUnit accessibilityMinutes;
   std::string accessibilityLabel{""};
   AccessibilityLabelledBy accessibilityLabelledBy{};
   AccessibilityLiveRegion accessibilityLiveRegion{

--- a/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -40,6 +40,8 @@ class AccessibilityProps {
   bool accessible{false};
   AccessibilityState accessibilityState;
   AccessibilityUnit accessibilityUnit;
+  int accessibilityHours;
+  int accessibilityMinutes;
   std::string accessibilityLabel{""};
   AccessibilityLabelledBy accessibilityLabelledBy{};
   AccessibilityLiveRegion accessibilityLiveRegion{

--- a/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.h
+++ b/ReactCommon/react/renderer/components/view/AccessibilityPropsMapBuffer.h
@@ -24,6 +24,8 @@ constexpr MapBuffer::Key AP_ACCESSIBILITY_VALUE = 7;
 constexpr MapBuffer::Key AP_ACCESSIBLE = 8;
 constexpr MapBuffer::Key AP_IMPORTANT_FOR_ACCESSIBILITY = 19;
 constexpr MapBuffer::Key AP_ACCESSIBILITY_UNIT = 47;
+constexpr MapBuffer::Key AP_ACCESSIBILITY_HOURS = 48;
+constexpr MapBuffer::Key AP_ACCESSIBILITY_MINUTES = 49;
 
 // AccessibilityAction values
 constexpr MapBuffer::Key ACCESSIBILITY_ACTION_NAME = 0;

--- a/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -191,6 +191,13 @@ inline void fromRawValue(
   */
 }
 
+inline void fromRawValue(
+    const PropsParserContext &context,
+    const RawValue &value,
+    int &result) {
+  result = 9;
+}
+
 inline std::string toString(
     const AccessibilityUnit &accessibilityUnit) {
   return "default string";

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -172,7 +172,7 @@ class AccessibilityExample extends React.Component<{}> {
               My number is
               <Text
                 accessibilityRole="time"
-                accessibilityUnit="an example of prop"
+                accessibilityUnit="10:30"
                 accessible={true}
                 style={{backgroundColor: 'red'}}>
                 17:00


### PR DESCRIPTION
The changes will crash the app at startup with the following stack trace

Related: https://github.com/facebook/react-native/pull/35130#issuecomment-1300800706 (was solved by modyfing the file and then running the artifacts)

Related PR https://github.com/fabriziobertoglio1987/react-native/pull/3
This functionalities will be part of future PR

<details><summary>full log</summary>
<p>

```
11-14 21:26:04.564 19462 19462 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
11-14 21:26:04.564 19462 19462 F DEBUG   : Build fingerprint: 'Redmi/camellian_id/camellian:11/RP1A.200720.011/V12.5.4.0.RKSIDXM:user/release-keys'
11-14 21:26:04.564 19462 19462 F DEBUG   : Revision: '0'
11-14 21:26:04.564 19462 19462 F DEBUG   : ABI: 'arm64'
11-14 21:26:04.565 19462 19462 F DEBUG   : Timestamp: 2022-11-14 21:26:04+0100
11-14 21:26:04.565 19462 19462 F DEBUG   : pid: 19337, tid: 19423, name: mqt_js  >>> com.facebook.react.uiapp <<<
11-14 21:26:04.565 19462 19462 F DEBUG   : uid: 10417
11-14 21:26:04.565 19462 19462 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
11-14 21:26:04.565 19462 19462 F DEBUG   : Abort message: '/Users/fabriziobertoglio/Sourcecode/opensource/react-native/ReactCommon/react/renderer/core/RawValue.h:271: function castValue: assertion failed (dynamic.isObject())'
11-14 21:26:04.565 19462 19462 F DEBUG   :     x0  0000000000000000  x1  0000000000004bdf  x2  0000000000000006  x3  0000007b7e4e8fd0
11-14 21:26:04.565 19462 19462 F DEBUG   :     x4  0000007b7e4e8a60  x5  0000007b7e4e8a60  x6  0000007b7e4e8a60  x7  0000000000000000
11-14 21:26:04.565 19462 19462 F DEBUG   :     x8  00000000000000f0  x9  0000007c972bf718  x10 ffffff80fffffbdf  x11 0000000000000001
11-14 21:26:04.565 19462 19462 F DEBUG   :     x12 000000001de49168  x13 0000000000000001  x14 000000000013a000  x15 0000000000000000
11-14 21:26:04.565 19462 19462 F DEBUG   :     x16 0000007c9738f948  x17 0000007c9736eb90  x18 0000007b7da42000  x19 0000000000004b89
11-14 21:26:04.565 19462 19462 F DEBUG   :     x20 0000000000004bdf  x21 00000000ffffffff  x22 0000007c13c46359  x23 0000000000000002
11-14 21:26:04.565 19462 19462 F DEBUG   :     x24 0000007c13c260a7  x25 0000000000000001  x26 0000007c13c3d037  x27 0000007c14235000
11-14 21:26:04.565 19462 19462 F DEBUG   :     x28 b400007c9a4ae360  x29 0000007b7e4e9050
11-14 21:26:04.565 19462 19462 F DEBUG   :     lr  0000007c973228c8  sp  0000007b7e4e8fb0  pc  0000007c973228f8  pst 0000000000001000
11-14 21:26:04.681 19462 19462 F DEBUG   : backtrace:
11-14 21:26:04.681 19462 19462 F DEBUG   :       #00 pc 00000000000898f8  /apex/com.android.runtime/lib64/bionic/libc.so (abort+168) (BuildId: 91daf2d5bf0aef9792c0820dfdc3c79e)
11-14 21:26:04.681 19462 19462 F DEBUG   :       #01 pc 0000000000552284  /apex/com.android.art/lib64/libart.so (art::Runtime::Abort(char const*)+2260) (BuildId: 372a904938922ad5207bc369223ccd45)
11-14 21:26:04.681 19462 19462 F DEBUG   :       #02 pc 0000000000013990  /system/lib64/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_3::__invoke(char const*)+76) (BuildId: 40363036c1f5a305d00fe1d058a86ccb)
11-14 21:26:04.681 19462 19462 F DEBUG   :       #03 pc 0000000000006e58  /system/lib64/liblog.so (__android_log_assert+336) (BuildId: a258efec13e9100f9a53e795c419da98)
11-14 21:26:04.681 19462 19462 F DEBUG   :       #04 pc 0000000000000728  /data/app/~~CKf-utu26a69kjr__380jA==/com.facebook.react.uiapp-iW5nq9fgff1KQOWeC701DQ==/lib/arm64/libreact_debug.so (react_native_assert_fail+104) (BuildId: 3ff5096a1517e0c6)
11-14 21:26:04.681 19462 19462 F DEBUG   :       #05 pc 00000000000b83a8  /data/app/~~CKf-utu26a69kjr__380jA==/com.facebook.react.uiapp-iW5nq9fgff1KQOWeC701DQ==/lib/arm64/librrc_view.so (folly::F14FastMap<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, folly::HeterogeneousAccessHash<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, void>, folly::HeterogeneousAccessEqualTo<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, void>, std::__ndk1::allocator<std::__ndk1::pair<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > > > > facebook::react::RawValue::castValue<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > >(folly::dynamic const&, folly::F14FastMap<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, folly::HeterogeneousAccessHash<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, void>, folly::HeterogeneousAccessEqualTo<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >, void>, std::__ndk1::allocator<std::__ndk1::pair<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > > > >*)+88) (BuildId: c526f14cf8933b15)
```

</p>
</details>