### PR TITLE
🚧 repeat VoiceOver interrupted announcement 🚧 

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -231,11 +231,6 @@ const Text: React.AbstractComponent<
   const _hasOnPressOrOnLongPress =
     props.onPress != null || props.onLongPress != null;
 
-  // 1) trigger the announcement and add to the queue
-  // 2) failure -> if first item in queue equal to the that failed
-  //    f --> edcb --> a
-  // 3) pop first item and trigger again announcement
-  // 4) when failure triggers, add it to the queue
   let retryAnnouncement;
   // the event listener detects if VoiceOver announcement fails
   AccessibilityInfo.addEventListener(

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -248,7 +248,7 @@ const Text: React.AbstractComponent<
         retryAnnouncement = null;
       }
 
-      if (!success && retryAnnouncement != announcement) {
+      if (!success && retryAnnouncement !== announcement) {
         console.log(
           'skip retry announcement for ' +
             announcement +
@@ -259,21 +259,20 @@ const Text: React.AbstractComponent<
   );
 
   // trigger voiceover announcement when text changes
-  if (Platform.OS === 'ios') {
-    React.useEffect(() => {
-      if (
-        restProps.accessibilityLiveRegion != null &&
-        restProps.accessibilityLiveRegion != 'none' &&
-        typeof restProps.children === 'string'
-      ) {
-        const queue = restProps.accessibilityLiveRegion === 'polite';
-        AccessibilityInfo.announceForAccessibilityWithOptions(
-          restProps.children,
-          {queue},
-        );
-      }
-    }, [restProps.children]);
-  }
+  React.useEffect(() => {
+    if (
+      Platform.OS === 'ios' &&
+      restProps.accessibilityLiveRegion != null &&
+      restProps.accessibilityLiveRegion !== 'none' &&
+      typeof restProps.children === 'string'
+    ) {
+      const queue = restProps.accessibilityLiveRegion === 'polite';
+      AccessibilityInfo.announceForAccessibilityWithOptions(
+        restProps.children,
+        {queue},
+      );
+    }
+  }, [restProps.children]);
 
   return hasTextAncestor ? (
     <NativeVirtualText

--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -113,9 +113,10 @@ using namespace facebook::react;
         attrsDictionary[UIAccessibilitySpeechAttributeQueueAnnouncement] =  @(accessibilityProps.accessibilityLiveRegion == AccessibilityLiveRegion::Polite ? YES : NO);
         NSAttributedString *announcementWithAttrs = [[NSAttributedString alloc] initWithString: self.accessibilityLabel
                                                                                     attributes:attrsDictionary];
+
         dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 0.5);
         dispatch_after(delay, dispatch_get_main_queue(), ^(void){
-          UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
+          // UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
         });
       }
     }

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -398,7 +398,7 @@ using namespace facebook::react;
         
         dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 0.5);
         dispatch_after(delay, dispatch_get_main_queue(), ^(void){
-          UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
+          // UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementWithAttrs);
         });
       }
     }


### PR DESCRIPTION
Draft implementation to test functionality with react-native
The retry logic should move to iOS objc as done with https://github.com/fabriziobertoglio1987/react-native/blob/e0eaa3c05fb5e10e7fcb25fe74a11006f80c5a30/React/CoreModules/RCTAccessibilityManager.mm#L105-L118

This solution is included to showcase an alternative solution to setTimeout:

- trigger accessibility event on iOS
- iOS callback detects failure to announce (system stops announcement) and retries

The JavaScript iOS APIs are already available in react-native, the first draft solution was implemented in JavaScript as Proof of Concept. The alternative is using `dispatch_after`.

Related https://github.com/facebook/react-native/pull/34969