### PR TITLE
Over-riding accessibilityLiveRegion in child component

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -304,11 +304,16 @@ using namespace facebook::react;
     if (newViewProps.accessibilityLiveRegion == AccessibilityLiveRegion::None) {
       newValueLiveRegion = @"none";
     };
-
-    for (RCTViewComponentView *subview in self.subviews) {
-      // add logic to over-ride behaviour when subview accessibilityLiveRegion is Polite or Assertive
-      if ([newValueLiveRegion length] != 0) {
-        subview.accessibilityLiveRegionAnnouncementType = newValueLiveRegion;
+    
+    if (![newValueLiveRegion isEqual:@"none"] && [newValueLiveRegion length] != 0) {
+      for (RCTViewComponentView *subview in self.subviews) {
+        // add logic to over-ride behaviour when subview accessibilityLiveRegion is Polite or Assertive
+        auto const &childAccessibilityProps = *std::static_pointer_cast<AccessibilityProps const>(_props);
+        if (childAccessibilityProps.accessibilityLiveRegion != AccessibilityLiveRegion::None) {
+          break;
+        } else {
+          subview.accessibilityLiveRegionAnnouncementType = newValueLiveRegion;
+        }
       }
     }
     self.accessibilityLiveRegionAnnouncementType = newValueLiveRegion;
@@ -318,7 +323,7 @@ using namespace facebook::react;
   NSMutableArray *accessibilityLiveRegionAnnouncementUpdate = [accessibilityLiveRegionAnnouncement mutableCopy];
   BOOL accessibilityLiveRegionEnabledFromParent = self.accessibilityLiveRegionAnnouncementType && ![self.accessibilityLiveRegionAnnouncementType isEqual:@"none"];
   BOOL isReactRootView = RCTIsReactRootView(self.reactTag);
-  BOOL accessibilityLiveRegionEnabled = newViewProps.accessibilityLiveRegion != AccessibilityLiveRegion::None;
+  BOOL accessibilityLiveRegionEnabled = newViewProps.accessible && newViewProps.accessibilityLiveRegion != AccessibilityLiveRegion::None;
   BOOL shouldAnnounceLiveRegionChanges = (accessibilityLiveRegionEnabledFromParent || accessibilityLiveRegionEnabled) && !isReactRootView;
   
   // `accessibilityLabel`

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1588,16 +1588,7 @@ function AccessibilityLiveRegion(): React.Node {
   const [liveRegion, setLiveRegion] = React.useState(true);
   return (
     <>
-      <RNTesterBlock title="LiveRegion with Text Component">
-        <TouchableWithoutFeedback
-          onPress={() => setCount(previousCount => previousCount + 1)}>
-          <View style={styles.embedded}>
-            <Text>Click me</Text>
-          </View>
-        </TouchableWithoutFeedback>
-        <Text accessibilityLiveRegion="polite">Clicked {count} times</Text>
-      </RNTesterBlock>
-      <RNTesterBlock title="LiveRegion with child component">
+      <RNTesterBlock title="Child liveRegion assertive stops the parent component announcement">
         <TouchableWithoutFeedback
           onPress={() =>
             setLiveRegion(liveRegionEnabled => !liveRegionEnabled)
@@ -1617,9 +1608,10 @@ function AccessibilityLiveRegion(): React.Node {
         <View
           accessible={true}
           focusable={true}
-          accessibilityLiveRegion={liveRegion ? 'assertive' : null}>
-          <TouchableOpacity
-            accessibilityLabel={enabled ? 'my label' : null}
+          accessibilityLabel={enabled ? 'my parent' : null}
+          accessibilityLiveRegion={liveRegion ? 'polite' : null}>
+          <View
+            accessible={false}
             accessibilityState={{disabled: enabled}}
             accessibilityHint={enabled ? 'my hint' : null}
             accessibilityValue={enabled ? {now: 5, min: 1, max: 10} : {}}
@@ -1630,6 +1622,15 @@ function AccessibilityLiveRegion(): React.Node {
             }}
           />
         </View>
+      </RNTesterBlock>
+      <RNTesterBlock title="LiveRegion with Text Component">
+        <TouchableWithoutFeedback
+          onPress={() => setCount(previousCount => previousCount + 1)}>
+          <View style={styles.embedded}>
+            <Text>Click me</Text>
+          </View>
+        </TouchableWithoutFeedback>
+        <Text accessibilityLiveRegion="polite">Clicked {count} times</Text>
       </RNTesterBlock>
     </>
   );


### PR DESCRIPTION
I moved the changes to a separate branch because:
- the same result is achieved by using accessible false to avoid announcing changes to child view
- accessibilityLiveRegion will not pass null from JS API and parse null as `@"none"` ([link](https://github.com/fabriziobertoglio1987/react-native/blob/b4c9698bbc5866a4d9d77475c30ac1338e522567/ReactCommon/react/renderer/components/view/AccessibilityProps.h#L45))
- the logic adds more complexity and it is error prone, as the same result is achieve with prop accessible={false}, I would postpone it

The main advantages of adding this changes is having different levels of Views with different levels of priority (for example parent with accessibilityLiveRegion polite will get interrupted by child with accessibilityLiveRegion assertive), which I believe is an additional feature.

Adding it to the original diff would make it very difficult to complete and review the PR.
I would prefer to work on this feature in a separate PR.

P | type | task
-- | -- | --
3 | bug | Over-riding accessibilityLiveRegion in child component
3.1 | task | Check value of subview prop accessibilityLiveRegion
3.2 | task | If subview live region does not equal to @“none”, stop loop

