### PR TITLE
🗑️ support fontSize in nested text vertical align - CLOSED 🗑️ 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -117,28 +117,33 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
       paint.getTextBounds(currentText, 0, currentText.length(), bounds);
       if (textAlignVertical == "top-child") {
         if (highestLineHeight != 0) {
-          // the span with the highest lineHeight over-rides sets the height for all rows
+          // the span with the highest lineHeight sets the height for all rows
           paint.baselineShift -= highestLineHeight / 2 - paint.getTextSize() / 2;
+        } else {
+          // works only with single line
+          // if lineHeight is not set, align the text using the font metrics
+          // https://stackoverflow.com/a/27631737/7295772
+          // top      -------------  -26          | +26   ^ -5
+          // ascent   -------------  -30  ^ -31   |       |
+          // baseline __my Text____   0   |       |       |
+          // descent  _____________   8   |       |
+          // bottom   _____________   1   |       V
+          paint.baselineShift -= bounds.bottom - paint.ascent() + bounds.top;
+        }
+      }
+      if (textAlignVertical == "bottom-child") {
+        if (highestLineHeight != 0) {
+          // the span with the highest lineHeight sets the height for all rows
+          paint.baselineShift += highestLineHeight / 2 - paint.getTextSize() / 2;
         } else {
           // works only with single line
           // if lineHeight is not set, align the text using the font metrics
           // https://stackoverflow.com/a/27631737/7295772
           // top      -------------  -26
           // ascent   -------------  -30
-          // baseline __my Text____   0
-          // descent  _____________   8
-          // bottom   _____________   1
-          paint.baselineShift -= bounds.top + bounds.bottom - paint.ascent();
-        }
-      }
-      if (textAlignVertical == "bottom-child") {
-        if (highestLineHeight != 0) {
-          // the span with the highest lineHeight over-rides sets the height for all rows
-          paint.baselineShift += highestLineHeight / 2 - paint.getTextSize() / 2;
-        } else {
-          // works only with single line
-          // if lineHeight is not set, align the text using the font metrics
-          // https://stackoverflow.com/a/27631737/7295772
+          // baseline __my Text____   0   |
+          // descent  _____________   8   | +8
+          // bottom   _____________   1   V
           paint.baselineShift += paint.descent();
         }
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
@@ -7,13 +7,29 @@
 
 package com.facebook.react.views.text;
 
+import android.text.TextPaint;
 import android.text.style.AbsoluteSizeSpan;
 
 /*
  * Wraps {@link AbsoluteSizeSpan} as a {@link ReactSpan}.
  */
 public class ReactAbsoluteSizeSpan extends AbsoluteSizeSpan implements ReactSpan {
-  public ReactAbsoluteSizeSpan(int size) {
+  private String mTextAlignVertical;
+
+  public ReactAbsoluteSizeSpan(int size, @Nullable String textAlignVertical) {
     super(size);
+    mTextAlignVertical = textVerticalAlign;
+  }
+
+  @Override
+  public void updateDrawState(TextPaint ds) {
+    if (mTextAlignVertical == "top-child") {
+      ds.baselineShift += 50;
+    }
+  }
+
+  @Override
+  public void updateMeasureState(TextPaint paint) {
+    // paint.baselineShift += 50;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -209,7 +209,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
                     textShadowNode.mFontWeight,
                     textShadowNode.mFontFeatureSettings,
                     textShadowNode.mFontFamily,
-                    textShadowNode.getThemedContext().getAssets(), /* textAlignVertical not supported on Paper */ null, null)));
+                    textShadowNode.getThemedContext().getAssets(), /* textAlignVertical not supported on Paper */ null, null, 0)));
       }
       if (textShadowNode.mIsUnderlineTextDecorationSet) {
         ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -156,7 +156,7 @@ public class TextLayoutManager {
                       textAttributes.mFontWeight,
                       textAttributes.mFontFeatureSettings,
                       textAttributes.mFontFamily,
-                      context.getAssets(), /* textAlignVertical not supported on Paper */ null, null)));
+                      context.getAssets(), /* textAlignVertical not supported on Paper */ null, null, 0)));
         }
         if (textAttributes.mIsUnderlineTextDecorationSet) {
           ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -159,7 +159,11 @@ public class TextLayoutManagerMapBuffer {
                   start, end, new CustomLetterSpacingSpan(textAttributes.getLetterSpacing())));
         }
         ops.add(
-            new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize)));
+            new SetSpanOperation(
+                start,
+                end,
+                new ReactAbsoluteSizeSpan(
+                    textAttributes.mFontSize, textAttributes.mVerticalAlign)));
         if (textAttributes.mFontStyle != UNSET
             || textAttributes.mFontWeight != UNSET
             || textAttributes.mFontFamily != null
@@ -176,7 +180,8 @@ public class TextLayoutManagerMapBuffer {
                       textAttributes.mFontFamily,
                       context.getAssets(),
                       textAttributes.mVerticalAlign,
-                      currentText)));
+                      currentText,
+                      textAttributes.mFontSize)));
         }
         if (textAttributes.mIsUnderlineTextDecorationSet) {
           ops.add(new SetSpanOperation(start, end, new ReactUnderlineSpan()));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -722,7 +722,7 @@ public class ReactEditText extends AppCompatEditText
                   mFontWeight,
                   null, // TODO: do we need to support FontFeatureSettings / fontVariant?
                   mFontFamily,
-                  getReactContext(ReactEditText.this).getAssets(), /* textAlignVertical not supported on TextInput */ null, null)));
+                  getReactContext(ReactEditText.this).getAssets(), /* textAlignVertical not supported on TextInput */ null, null, 0)));
     }
     if (!Float.isNaN(mTextAttributes.getEffectiveLineHeight())) {
       ops.add(


### PR DESCRIPTION
Child of PR https://github.com/facebook/react-native/pull/35704

requires moving the logic to AbsSizeSpan and calculate the ratio use to increase the original font

FontMetrics (top, bottom, ascent and descent) are calculated on the original fontSize
They are not updated after changing fontSize. Increase the fontSize to text would log same fontMetrics

```
// top      -------------  -26 
// ascent   -------------  -30 
// baseline __my Text____   0  
// descent  _____________   8  
// bottom   _____________   1  
```
To work around this, we need to store the original fontSize (for ex. 1) and the new fontSize (for ex. 20) and calculate a ratio.

The ration is used to adjust the fontMetrics to the new fontSize.
The result is used to shift the baseline of the font to align top or bottom