### PR TITLE
🗑️ Calculate line height and font metrics - CLOSED 🗑️  

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -38,6 +38,8 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
   private final String mCurrentText;
   private String mTextAlignVertical;
   private int mHighestLineHeight;
+  private int mLineHeight;
+  private int mLineCount;
 
   public CustomStyleSpan(
       int fontStyle,
@@ -67,7 +69,8 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
         mAssetManager,
         mTextAlignVertical,
         mCurrentText,
-        mHighestLineHeight);
+        mHighestLineHeight,
+        mLineHeight);
   }
 
   @Override
@@ -81,7 +84,8 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
         mAssetManager,
         mTextAlignVertical,
         mCurrentText,
-        mHighestLineHeight);
+        mHighestLineHeight,
+        mLineHeight);
   }
 
   public int getStyle() {
@@ -105,7 +109,8 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
       AssetManager assetManager,
       @Nullable String textAlignVertical,
       String currentText,
-      int highestLineHeight) {
+      int highestLineHeight,
+      int lineHeight) {
     Typeface typeface =
         ReactTypefaceUtils.applyStyles(paint.getTypeface(), style, weight, family, assetManager);
     paint.setFontFeatureSettings(fontFeatureSettings);
@@ -119,33 +124,39 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
         if (highestLineHeight != 0) {
           // the span with the highest lineHeight sets the height for all rows
           paint.baselineShift -= highestLineHeight / 2 - paint.getTextSize() / 2;
+        } else if (lineHeight > 0) {
+          paint.baselineShift -= lineHeight / 2 - paint.getTextSize() / 2;
         } else {
           // works only with single line and without fontSize
           // https://bit.ly/3W2eJKT
           // if lineHeight is not set, align the text using the font metrics
           // https://stackoverflow.com/a/27631737/7295772
-          // top      -------------  -26
-          // ascent   -------------  -30
-          // baseline __my Text____   0
-          // descent  _____________   8
-          // bottom   _____________   1
-          paint.baselineShift += paint.getFontMetrics().top - paint.getFontMetrics().ascent;
+          // top      -------------
+          // ascent   -------------
+          // baseline __my Text____
+          // descent  _____________
+          // bottom   _____________
+          // paint.baselineShift += paint.getFontMetrics().top - paint.getFontMetrics().ascent;
         }
       }
       if (textAlignVertical == "bottom-child") {
         if (highestLineHeight != 0) {
           // the span with the highest lineHeight sets the height for all rows
           paint.baselineShift += highestLineHeight / 2 - paint.getTextSize() / 2;
+        } else if (lineHeight > 0) {
+          paint.baselineShift += lineHeight / 2 - paint.getTextSize() / 2;
         } else {
           // works only with single line and without fontSize
           // https://bit.ly/3W2eJKT
-          paint.baselineShift += paint.getFontMetrics().bottom - paint.descent();
+          // paint.baselineShift += paint.getFontMetrics().bottom - paint.descent();
         }
       }
     }
   }
 
-  public void updateSpan(int highestLineHeight) {
+  public void updateSpan(int highestLineHeight, int lineCount, int lineHeight) {
     mHighestLineHeight = highestLineHeight;
+    mLineCount = lineCount;
+    mLineHeight = lineHeight;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -13,11 +13,13 @@ import android.graphics.Typeface;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Nullsafe;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
 
+  private static final String TAG = "CustomStyleSpan";
   /**
    * A {@link MetricAffectingSpan} that allows to change the style of the displayed font.
    * CustomStyleSpan will try to load the fontFamily with the right style and weight from the
@@ -125,7 +127,22 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
           // the span with the highest lineHeight sets the height for all rows
           paint.baselineShift -= highestLineHeight / 2 - paint.getTextSize() / 2;
         } else if (lineHeight > 0) {
-          paint.baselineShift -= lineHeight / 2 - paint.getTextSize() / 2;
+          float fontHeight = paint.getFontMetrics().bottom - paint.getFontMetrics().top;
+          String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+          FLog.w(
+              "React::" + TAG,
+              methodName
+                  + " currentText: "
+                  + (currentText)
+                  + " fontHeight: "
+                  + (fontHeight)
+                  + " lineHeight: "
+                  + (lineHeight)
+                  + " paint.getFontMetrics().top: "
+                  + (paint.getFontMetrics().top)
+                  + " paint.getFontMetrics().bottom: "
+                  + (paint.getFontMetrics().bottom));
+          paint.baselineShift -= lineHeight - paint.getTextSize();
         } else {
           // works only with single line and without fontSize
           // https://bit.ly/3W2eJKT
@@ -144,7 +161,7 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
           // the span with the highest lineHeight sets the height for all rows
           paint.baselineShift += highestLineHeight / 2 - paint.getTextSize() / 2;
         } else if (lineHeight > 0) {
-          paint.baselineShift += lineHeight / 2 - paint.getTextSize() / 2;
+          paint.baselineShift += lineHeight - paint.getTextSize();
         } else {
           // works only with single line and without fontSize
           // https://bit.ly/3W2eJKT

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -129,7 +129,7 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
           // baseline __my Text____   0
           // descent  _____________   8
           // bottom   _____________   1
-          paint.baselineShift -= bounds.bottom - paint.ascent() + bounds.top;
+          paint.baselineShift += paint.getFontMetrics().top - paint.getFontMetrics().ascent;
         }
       }
       if (textAlignVertical == "bottom-child") {
@@ -139,7 +139,7 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
         } else {
           // works only with single line and without fontSize
           // https://bit.ly/3W2eJKT
-          paint.baselineShift += paint.descent();
+          paint.baselineShift += paint.getFontMetrics().bottom - paint.descent();
         }
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
@@ -7,13 +7,33 @@
 
 package com.facebook.react.views.text;
 
+import android.text.TextPaint;
 import android.text.style.AbsoluteSizeSpan;
+import androidx.annotation.NonNull;
+import com.facebook.common.logging.FLog;
 
 /*
  * Wraps {@link AbsoluteSizeSpan} as a {@link ReactSpan}.
  */
 public class ReactAbsoluteSizeSpan extends AbsoluteSizeSpan implements ReactSpan {
+  private static final String TAG = "ReactAbsoluteSizeSpan";
+
   public ReactAbsoluteSizeSpan(int size) {
     super(size);
+  }
+
+  @Override
+  public void updateDrawState(@NonNull TextPaint ds) {
+    super.updateDrawState(ds);
+    String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+    FLog.w(
+        "React::" + TAG,
+        methodName
+            + " ds.getFontMetrics().top: "
+            + (ds.getFontMetrics().top)
+            + " ds.getFontMetrics().bottom: "
+            + (ds.getFontMetrics().bottom)
+            + " getSize(): "
+            + (getSize()));
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -8,9 +8,11 @@
 package com.facebook.react.views.text;
 
 import android.content.Context;
+import android.text.Layout;
 import android.text.Spannable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
@@ -43,6 +45,7 @@ public class ReactTextViewManager
   private static final short TX_STATE_KEY_MOST_RECENT_EVENT_COUNT = 3;
 
   @VisibleForTesting public static final String REACT_CLASS = "RCTText";
+  private static final String TAG = "ReactTextViewManager";
 
   protected @Nullable ReactTextViewManagerCallback mReactTextViewManagerCallback;
 
@@ -104,20 +107,27 @@ public class ReactTextViewManager
 
     CustomLineHeightSpan[] customLineHeightSpans =
         spannable.getSpans(0, spannable.length(), CustomLineHeightSpan.class);
+    int highestLineHeight = 0;
     if (customLineHeightSpans.length > 0) {
-      int highestLineHeight = 0;
       for (CustomLineHeightSpan span : customLineHeightSpans) {
         if (highestLineHeight == 0 || span.getLineHeight() > highestLineHeight) {
           highestLineHeight = span.getLineHeight();
         }
       }
+    }
 
-      CustomStyleSpan[] customStyleSpans =
-          spannable.getSpans(0, spannable.length(), CustomStyleSpan.class);
-      if (customStyleSpans.length != 0) {
-        for (CustomStyleSpan span : customStyleSpans) {
-          span.updateSpan(highestLineHeight);
-        }
+    CustomStyleSpan[] customStyleSpans =
+        spannable.getSpans(0, spannable.length(), CustomStyleSpan.class);
+    if (customStyleSpans.length != 0) {
+      Layout layout = view.getLayout();
+      int lineCount = layout != null ? layout.getLineCount() : 1;
+      int lineHeight = layout != null ? layout.getHeight() : 0;
+      String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
+      FLog.w(
+          "React::" + TAG,
+          methodName + " update.getText(): " + (update.getText()) + " lineHeight: " + (lineHeight));
+      for (CustomStyleSpan span : customStyleSpans) {
+        span.updateSpan(highestLineHeight, lineCount, lineHeight);
       }
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -12,7 +12,6 @@ import android.text.Layout;
 import android.text.Spannable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
@@ -122,10 +121,6 @@ public class ReactTextViewManager
       Layout layout = view.getLayout();
       int lineCount = layout != null ? layout.getLineCount() : 1;
       int lineHeight = layout != null ? layout.getHeight() : 0;
-      String methodName = new Object() {}.getClass().getEnclosingMethod().getName();
-      FLog.w(
-          "React::" + TAG,
-          methodName + " update.getText(): " + (update.getText()) + " lineHeight: " + (lineHeight));
       for (CustomStyleSpan span : customStyleSpans) {
         span.updateSpan(highestLineHeight, lineCount, lineHeight);
       }

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -312,6 +312,7 @@ class NestedTextVerticalAlign extends React.Component<{...}> {
           <Text>
             vertical align is set to{' '}
             <Text style={{backgroundColor: 'red'}}>{textAlignVertical}</Text>
+            <Text style={{backgroundColor: 'green'}}>{fontSize}</Text>
           </Text>
           <Button
             onPress={() => this.changeVerticalAlign()}
@@ -323,20 +324,25 @@ class NestedTextVerticalAlign extends React.Component<{...}> {
           />
           <Button onPress={() => this.increaseFont()} title="increase font" />
           <View>
-            <Text
-              style={{
-                fontSize,
-                backgroundColor: 'yellow',
-              }}>
+            <View style={{height: 300, backgroundColor: 'red'}}>
               <Text
                 style={{
-                  textAlignVertical,
-                  backgroundColor: 'green',
-                  color: 'white',
+                  flex: 1,
+                  fontSize,
+                  textAlignVertical: 'center',
+                  allowFontScaling: false,
+                  backgroundColor: 'yellow',
                 }}>
-                Custom font
+                <Text
+                  style={{
+                    textAlignVertical,
+                    backgroundColor: 'green',
+                    color: 'white',
+                  }}>
+                  CusTom teXt PjYx;,\
+                </Text>
               </Text>
-            </Text>
+            </View>
             <Text>
               Without lineHeight prop, the green text is correctly aligned, but
               does not support ReactAbsoluteSizeSpan (nested Text with different


### PR DESCRIPTION
Child of PR https://github.com/facebook/react-native/pull/35704

requires moving the logic to AbsSizeSpan and calculate the ratio use to increase the original font

FontMetrics (top, bottom, ascent and descent) are calculated on the original fontSize
They are not updated after changing fontSize. Increase the fontSize to text would log same fontMetrics

```
// top      -------------  -26 
// ascent   -------------  -30 
// baseline __my Text____   0  
// descent  _____________   8  
// bottom   _____________   1  
```
To work around this, we need to store the original fontSize (for ex. 1) and the new fontSize (for ex. 20) and calculate a ratio.

The ration is used to adjust the fontMetrics to the new fontSize.
The result is used to shift the baseline of the font to align top or bottom