### PR TITLE
🗑️  Calculate font top and bottom with different fontSizes - CLOSED 🗑️ 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomStyleSpan.java
@@ -109,10 +109,10 @@ public class CustomStyleSpan extends MetricAffectingSpan implements ReactSpan {
     // other use cases will be added in separate PRs
     // the span with the highest lineHeight sets the height for all rows
     if (textAlignVertical == "top-child" && highestLineHeight != 0) {
-      tp.baselineShift -= highestLineHeight / 2 - tp.getTextSize() / 2;
+      // tp.baselineShift -= highestLineHeight / 2 - tp.getTextSize() / 2;
     }
     if (textAlignVertical == "bottom-child" && highestLineHeight != 0) {
-      tp.baselineShift += highestLineHeight / 2 - tp.getTextSize() / 2;
+      // tp.baselineShift += highestLineHeight / 2 - tp.getTextSize() / 2;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactAbsoluteSizeSpan.java
@@ -7,13 +7,51 @@
 
 package com.facebook.react.views.text;
 
+import android.graphics.Rect;
+import android.text.TextPaint;
 import android.text.style.AbsoluteSizeSpan;
+import androidx.annotation.Nullable;
 
 /*
  * Wraps {@link AbsoluteSizeSpan} as a {@link ReactSpan}.
  */
 public class ReactAbsoluteSizeSpan extends AbsoluteSizeSpan implements ReactSpan {
-  public ReactAbsoluteSizeSpan(int size) {
+  private static final String TAG = "ReactAbsoluteSizeSpan";
+  private final String mText;
+  private String mTextAlignVertical = "center-child";
+
+  public ReactAbsoluteSizeSpan(
+      int size, @Nullable String textAlignVertical, @Nullable String text) {
     super(size);
+    mTextAlignVertical = textAlignVertical;
+    mText = text;
+  }
+
+  @Override
+  public void updateMeasureState(TextPaint tp) {
+    updateDrawState(tp);
+  }
+
+  @Override
+  public void updateDrawState(TextPaint ds) {
+    super.updateDrawState(ds);
+    // if lineHeight is not set, align the text using the font metrics
+    // works only with single line
+    // https://stackoverflow.com/a/27631737/7295772
+    // top      -------------  -26
+    // ascent   -------------  -30
+    // baseline __my Text____   0
+    // descent  _____________   8
+    // bottom   _____________   1
+    if (mText != null) {
+      Rect bounds = new Rect();
+      ds.getTextBounds(mText, 0, mText.length(), bounds);
+      if (mTextAlignVertical == "top-child") {
+        ds.baselineShift += ds.getFontMetrics().top - ds.ascent() - ds.descent();
+      }
+      if (mTextAlignVertical == "bottom-child") {
+        ds.baselineShift += ds.getFontMetrics().bottom - ds.descent();
+      }
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -195,7 +195,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       // `Float.NaN`.
       parentTextAttributes == null
           || parentTextAttributes.getEffectiveFontSize() != effectiveFontSize) {
-        ops.add(new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(effectiveFontSize)));
+        ops.add(new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(effectiveFontSize, null, null)));
       }
       if (textShadowNode.mFontStyle != UNSET
           || textShadowNode.mFontWeight != UNSET

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -95,7 +95,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               for (ReactAbsoluteSizeSpan span : sizeSpans) {
                 text.setSpan(
                     new ReactAbsoluteSizeSpan(
-                        (int) Math.max((span.getSize() * ratio), minimumFontSize)),
+                        (int) Math.max((span.getSize() * ratio), minimumFontSize), null, null),
                     text.getSpanStart(span),
                     text.getSpanEnd(span),
                     text.getSpanFlags(span));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -143,7 +143,7 @@ public class TextLayoutManager {
                   start, end, new CustomLetterSpacingSpan(textAttributes.getLetterSpacing())));
         }
         ops.add(
-            new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize)));
+            new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize, null, null)));
         if (textAttributes.mFontStyle != UNSET
             || textAttributes.mFontWeight != UNSET
             || textAttributes.mFontFamily != null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -158,8 +158,13 @@ public class TextLayoutManagerMapBuffer {
               new SetSpanOperation(
                   start, end, new CustomLetterSpacingSpan(textAttributes.getLetterSpacing())));
         }
+        String currentText = String.valueOf(sb.subSequence(start, end));
         ops.add(
-            new SetSpanOperation(start, end, new ReactAbsoluteSizeSpan(textAttributes.mFontSize)));
+            new SetSpanOperation(
+                start,
+                end,
+                new ReactAbsoluteSizeSpan(
+                    textAttributes.mFontSize, textAttributes.mTextAlignVertical, currentText)));
         if (textAttributes.mFontStyle != UNSET
             || textAttributes.mFontWeight != UNSET
             || textAttributes.mFontFamily != null

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -711,7 +711,7 @@ public class ReactEditText extends AppCompatEditText
     }
     ops.add(
         new TextLayoutManager.SetSpanOperation(
-            start, end, new ReactAbsoluteSizeSpan((int) mTextAttributes.getEffectiveFontSize())));
+            start, end, new ReactAbsoluteSizeSpan((int) mTextAttributes.getEffectiveFontSize(), null, null)));
     if (mFontStyle != UNSET || mFontWeight != UNSET || mFontFamily != null) {
       ops.add(
           new TextLayoutManager.SetSpanOperation(


### PR DESCRIPTION
Child of PR https://github.com/facebook/react-native/pull/35704

requires moving the logic to AbsSizeSpan and calculate the ratio use to increase the original font

FontMetrics (top, bottom, ascent and descent) are calculated on the original fontSize
They are not updated after changing fontSize. Increase the fontSize to text would log same fontMetrics

```
// top      -------------  -26 
// ascent   -------------  -30 
// baseline __my Text____   0  
// descent  _____________   8  
// bottom   _____________   1  
```
To work around this, we need to store the original fontSize (for ex. 1) and the new fontSize (for ex. 20) and calculate a ratio.

The ration is used to adjust the fontMetrics to the new fontSize.
The result is used to shift the baseline of the font to align top or bottom